### PR TITLE
[fix] do not need commit again if format changes

### DIFF
--- a/prepare.py
+++ b/prepare.py
@@ -6,6 +6,7 @@ cmake -B build
 cmake --build build -j8
 cmake --build build --target clang-format
 echo "Run clang-format done"
+git add -u
 """
 
 with open(file_name, "w") as file:


### PR DESCRIPTION
为了避免 clang-format 后需要重新 commit